### PR TITLE
PN-3301 aggiunti log MDC in chiamate asincrone di dynamo

### DIFF
--- a/src/main/java/it/pagopa/pn/mandate/services/mandate/v1/MandateService.java
+++ b/src/main/java/it/pagopa/pn/mandate/services/mandate/v1/MandateService.java
@@ -68,7 +68,7 @@ public class MandateService  {
      * @param internaluserId iuid del delegato
      * @return void
      */
-    public Mono<Object> acceptMandate(String mandateId, Mono<AcceptRequestDto> acceptRequestDto,
+    public Mono<MandateEntity> acceptMandate(String mandateId, Mono<AcceptRequestDto> acceptRequestDto,
             String internaluserId) {
         return acceptRequestDto
         .map(m -> {

--- a/src/main/java/it/pagopa/pn/mandate/springbootcfg/AwsServicesClientsConfigActivation.java
+++ b/src/main/java/it/pagopa/pn/mandate/springbootcfg/AwsServicesClientsConfigActivation.java
@@ -3,7 +3,13 @@ package it.pagopa.pn.mandate.springbootcfg;
 import it.pagopa.pn.commons.configs.RuntimeMode;
 import it.pagopa.pn.commons.configs.aws.AwsConfigs;
 import it.pagopa.pn.commons.configs.aws.AwsServicesClientsConfig;
+import it.pagopa.pn.mandate.utils.DynamoDbAsyncClientDecorator;
+import it.pagopa.pn.mandate.utils.DynamoDbEnhancedAsyncClientDecorator;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 
 @Configuration
 public class AwsServicesClientsConfigActivation extends AwsServicesClientsConfig {
@@ -11,4 +17,17 @@ public class AwsServicesClientsConfigActivation extends AwsServicesClientsConfig
     public AwsServicesClientsConfigActivation(AwsConfigs props) {
         super(props, RuntimeMode.PROD);
     }
+
+    @Bean
+    @Primary
+    DynamoDbAsyncClient dynamoDbAsyncClientDecorator(DynamoDbAsyncClient delegate) {
+        return new DynamoDbAsyncClientDecorator(delegate);
+    }
+
+    @Bean
+    @Primary
+    DynamoDbEnhancedAsyncClient dynamoDbEnhancedAsyncClientDecorator(DynamoDbEnhancedAsyncClient delegate) {
+        return new DynamoDbEnhancedAsyncClientDecorator(delegate);
+    }
+
 }

--- a/src/main/java/it/pagopa/pn/mandate/utils/DynamoDbAsyncClientDecorator.java
+++ b/src/main/java/it/pagopa/pn/mandate/utils/DynamoDbAsyncClientDecorator.java
@@ -1,0 +1,108 @@
+package it.pagopa.pn.mandate.utils;
+
+import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
+import software.amazon.awssdk.services.dynamodb.model.*;
+import software.amazon.awssdk.services.dynamodb.paginators.QueryPublisher;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+public class DynamoDbAsyncClientDecorator implements DynamoDbAsyncClient {
+
+    private final DynamoDbAsyncClient dynamoDbAsyncClient;
+
+    public DynamoDbAsyncClientDecorator(DynamoDbAsyncClient dynamoDbAsyncClient) {
+        this.dynamoDbAsyncClient = dynamoDbAsyncClient;
+    }
+
+    @Override
+    public String serviceName() {
+        return this.dynamoDbAsyncClient.serviceName();
+    }
+
+    @Override
+    public void close() {
+        this.dynamoDbAsyncClient.close();
+    }
+
+    @Override
+    public CompletableFuture<QueryResponse> query(Consumer<QueryRequest.Builder> queryRequest) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncClient.query(queryRequest)
+                .thenApply(queryResponse -> MDCUtils.enrichWithMDC(queryResponse, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<QueryResponse> query(QueryRequest queryRequest) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncClient.query(queryRequest)
+                .thenApply(queryResponse -> MDCUtils.enrichWithMDC(queryResponse, copyOfContextMap));
+    }
+
+    @Override
+    public QueryPublisher queryPaginator(Consumer<QueryRequest.Builder> queryRequest) {
+        return this.dynamoDbAsyncClient.queryPaginator(queryRequest);
+    }
+
+    @Override
+    public QueryPublisher queryPaginator(QueryRequest queryRequest) {
+        return this.dynamoDbAsyncClient.queryPaginator(queryRequest);
+    }
+
+    @Override
+    public CompletableFuture<PutItemResponse> putItem(Consumer<PutItemRequest.Builder> putItemRequest) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncClient.putItem(putItemRequest)
+                .thenApply(putItemResponse -> MDCUtils.enrichWithMDC(putItemResponse, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<PutItemResponse> putItem(PutItemRequest putItemRequest) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncClient.putItem(putItemRequest)
+                .thenApply(putItemResponse -> MDCUtils.enrichWithMDC(putItemResponse, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<TransactWriteItemsResponse> transactWriteItems(Consumer<TransactWriteItemsRequest.Builder> transactWriteItemsRequest) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncClient.transactWriteItems(transactWriteItemsRequest)
+                .thenApply(transactWriteItemsResponse -> MDCUtils.enrichWithMDC(transactWriteItemsResponse, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<TransactWriteItemsResponse> transactWriteItems(TransactWriteItemsRequest transactWriteItemsRequest) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncClient.transactWriteItems(transactWriteItemsRequest)
+                .thenApply(transactWriteItemsResponse -> MDCUtils.enrichWithMDC(transactWriteItemsResponse, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<GetItemResponse> getItem(Consumer<GetItemRequest.Builder> getItemRequest) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncClient.getItem(getItemRequest)
+                .thenApply(getItemResponse -> MDCUtils.enrichWithMDC(getItemResponse, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<GetItemResponse> getItem(GetItemRequest getItemRequest) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncClient.getItem(getItemRequest)
+                .thenApply(getItemResponse -> MDCUtils.enrichWithMDC(getItemResponse, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<DeleteItemResponse> deleteItem(Consumer<DeleteItemRequest.Builder> deleteItemRequest) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncClient.deleteItem(deleteItemRequest)
+                .thenApply(deleteItemResponse -> MDCUtils.enrichWithMDC(deleteItemResponse, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<DeleteItemResponse> deleteItem(DeleteItemRequest deleteItemRequest) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncClient.deleteItem(deleteItemRequest)
+                .thenApply(deleteItemResponse -> MDCUtils.enrichWithMDC(deleteItemResponse, copyOfContextMap));
+    }
+}

--- a/src/main/java/it/pagopa/pn/mandate/utils/DynamoDbAsyncIndexDecorator.java
+++ b/src/main/java/it/pagopa/pn/mandate/utils/DynamoDbAsyncIndexDecorator.java
@@ -1,0 +1,69 @@
+package it.pagopa.pn.mandate.utils;
+
+
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncIndex;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClientExtension;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.Page;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
+
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class DynamoDbAsyncIndexDecorator<T> implements DynamoDbAsyncIndex<T> {
+
+    private final DynamoDbAsyncIndex<T> tDynamoDbAsyncIndex;
+
+    public DynamoDbAsyncIndexDecorator(DynamoDbAsyncIndex<T> tDynamoDbAsyncIndex) {
+        this.tDynamoDbAsyncIndex = tDynamoDbAsyncIndex;
+    }
+
+    @Override
+    public DynamoDbEnhancedClientExtension mapperExtension() {
+        return null;
+    }
+
+    @Override
+    public TableSchema<T> tableSchema() {
+        return this.tDynamoDbAsyncIndex.tableSchema();
+    }
+
+    @Override
+    public String tableName() {
+        return this.tDynamoDbAsyncIndex.tableName();
+    }
+
+    @Override
+    public String indexName() {
+        return this.tDynamoDbAsyncIndex.indexName();
+    }
+
+    @Override
+    public Key keyFrom(T item) {
+        return this.tDynamoDbAsyncIndex.keyFrom(item);
+    }
+
+    @Override
+    public SdkPublisher<Page<T>> query(QueryConditional queryConditional) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.tDynamoDbAsyncIndex.query(queryConditional)
+                .map(tPage -> MDCUtils.enrichWithMDC(tPage, copyOfContextMap));
+    }
+
+    @Override
+    public SdkPublisher<Page<T>> query(QueryEnhancedRequest request) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.tDynamoDbAsyncIndex.query(request)
+                .map(tPage -> MDCUtils.enrichWithMDC(tPage, copyOfContextMap));
+    }
+
+    @Override
+    public SdkPublisher<Page<T>> query(Consumer<QueryEnhancedRequest.Builder> requestConsumer) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.tDynamoDbAsyncIndex.query(requestConsumer)
+                .map(tPage -> MDCUtils.enrichWithMDC(tPage, copyOfContextMap));
+    }
+}

--- a/src/main/java/it/pagopa/pn/mandate/utils/DynamoDbAsyncTableDecorator.java
+++ b/src/main/java/it/pagopa/pn/mandate/utils/DynamoDbAsyncTableDecorator.java
@@ -1,0 +1,145 @@
+package it.pagopa.pn.mandate.utils;
+
+import software.amazon.awssdk.core.async.SdkPublisher;
+import software.amazon.awssdk.enhanced.dynamodb.*;
+import software.amazon.awssdk.enhanced.dynamodb.model.*;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+public class DynamoDbAsyncTableDecorator<T> implements DynamoDbAsyncTable<T> {
+
+    private final DynamoDbAsyncTable<T> dynamoDbAsyncTable;
+
+    public DynamoDbAsyncTableDecorator(DynamoDbAsyncTable<T> dynamoDbAsyncTable) {
+        this.dynamoDbAsyncTable = dynamoDbAsyncTable;
+    }
+
+    @Override
+    public DynamoDbAsyncIndex<T> index(String s) {
+        DynamoDbAsyncIndex<T> index = this.dynamoDbAsyncTable.index(s);
+        return new DynamoDbAsyncIndexDecorator<>(index);
+    }
+
+    @Override
+    public DynamoDbEnhancedClientExtension mapperExtension() {
+        return this.dynamoDbAsyncTable.mapperExtension();
+    }
+
+    @Override
+    public TableSchema<T> tableSchema() {
+        return this.dynamoDbAsyncTable.tableSchema();
+    }
+
+    @Override
+    public String tableName() {
+        return this.dynamoDbAsyncTable.tableName();
+    }
+
+    @Override
+    public Key keyFrom(T t) {
+        return this.dynamoDbAsyncTable.keyFrom(t);
+    }
+
+    @Override
+    public PagePublisher<T> query(QueryEnhancedRequest request) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        SdkPublisher<Page<T>> map = this.dynamoDbAsyncTable.query(request)
+                .map(tPage -> MDCUtils.enrichWithMDC(tPage, copyOfContextMap));
+        return PagePublisher.create(map);
+    }
+
+    @Override
+    public PagePublisher<T> query(Consumer<QueryEnhancedRequest.Builder> requestConsumer) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        SdkPublisher<Page<T>> publisherWithMDC = this.dynamoDbAsyncTable.query(requestConsumer)
+                .map(tPage -> MDCUtils.enrichWithMDC(tPage, copyOfContextMap));
+        return PagePublisher.create(publisherWithMDC);
+    }
+
+    @Override
+    public PagePublisher<T> query(QueryConditional queryConditional) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        SdkPublisher<Page<T>> publisherWithMDC = this.dynamoDbAsyncTable.query(queryConditional)
+                .map(tPage -> MDCUtils.enrichWithMDC(tPage, copyOfContextMap));
+        return PagePublisher.create(publisherWithMDC);
+    }
+
+    @Override
+    public CompletableFuture<Void> putItem(PutItemEnhancedRequest<T> request) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.putItem(request)
+                .thenApply(unused -> MDCUtils.enrichWithMDC(unused, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<Void> putItem(Consumer<PutItemEnhancedRequest.Builder<T>> requestConsumer) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.putItem(requestConsumer)
+                .thenApply(unused -> MDCUtils.enrichWithMDC(unused, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<Void> putItem(T item) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.putItem(item)
+                .thenApply(unused -> MDCUtils.enrichWithMDC(unused, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<T> getItem(Key key) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.getItem(key)
+                .thenApply(t -> MDCUtils.enrichWithMDC(t, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<T> getItem(T keyItem) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.getItem(keyItem)
+                .thenApply(t -> MDCUtils.enrichWithMDC(t, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<T> getItem(Consumer<GetItemEnhancedRequest.Builder> requestConsumer) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.getItem(requestConsumer)
+                .thenApply(t -> MDCUtils.enrichWithMDC(t, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<T> getItem(GetItemEnhancedRequest request) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.getItem(request)
+                .thenApply(t -> MDCUtils.enrichWithMDC(t, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<T> deleteItem(Consumer<DeleteItemEnhancedRequest.Builder> requestConsumer) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.deleteItem(requestConsumer)
+                .thenApply(t -> MDCUtils.enrichWithMDC(t, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<T> deleteItem(DeleteItemEnhancedRequest request) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.deleteItem(request)
+                .thenApply(t -> MDCUtils.enrichWithMDC(t, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<T> deleteItem(Key key) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.deleteItem(key)
+                .thenApply(t -> MDCUtils.enrichWithMDC(t, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<T> deleteItem(T keyItem) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbAsyncTable.deleteItem(keyItem)
+                .thenApply(t -> MDCUtils.enrichWithMDC(t, copyOfContextMap));
+    }
+}

--- a/src/main/java/it/pagopa/pn/mandate/utils/DynamoDbEnhancedAsyncClientDecorator.java
+++ b/src/main/java/it/pagopa/pn/mandate/utils/DynamoDbEnhancedAsyncClientDecorator.java
@@ -1,0 +1,38 @@
+package it.pagopa.pn.mandate.utils;
+
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+public class DynamoDbEnhancedAsyncClientDecorator implements DynamoDbEnhancedAsyncClient {
+
+    private final DynamoDbEnhancedAsyncClient dynamoDbEnhancedAsyncClient;
+
+    public DynamoDbEnhancedAsyncClientDecorator(DynamoDbEnhancedAsyncClient dynamoDbEnhancedAsyncClient) {
+        this.dynamoDbEnhancedAsyncClient = dynamoDbEnhancedAsyncClient;
+    }
+
+    @Override
+    public <T> DynamoDbAsyncTable<T> table(String s, TableSchema<T> tableSchema) {
+        return new DynamoDbAsyncTableDecorator<>(this.dynamoDbEnhancedAsyncClient.table(s, tableSchema));
+    }
+
+    @Override
+    public CompletableFuture<Void> transactWriteItems(Consumer<TransactWriteItemsEnhancedRequest.Builder> requestConsumer) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbEnhancedAsyncClient.transactWriteItems(requestConsumer)
+                .thenApply(queryResponse -> MDCUtils.enrichWithMDC(queryResponse, copyOfContextMap));
+    }
+
+    @Override
+    public CompletableFuture<Void> transactWriteItems(TransactWriteItemsEnhancedRequest request) {
+        Map<String, String> copyOfContextMap = MDCUtils.retrieveMDCContextMap();
+        return this.dynamoDbEnhancedAsyncClient.transactWriteItems(request)
+                .thenApply(queryResponse -> MDCUtils.enrichWithMDC(queryResponse, copyOfContextMap));
+    }
+}

--- a/src/main/java/it/pagopa/pn/mandate/utils/MDCUtils.java
+++ b/src/main/java/it/pagopa/pn/mandate/utils/MDCUtils.java
@@ -1,0 +1,22 @@
+package it.pagopa.pn.mandate.utils;
+
+import org.slf4j.MDC;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Map;
+
+public class MDCUtils {
+
+    private MDCUtils() {}
+
+    public static Map<String, String> retrieveMDCContextMap() {
+        return MDC.getCopyOfContextMap();
+    }
+
+    public static <V> V enrichWithMDC(V t, Map<String, String> copyOfContextMap) {
+        if(! CollectionUtils.isEmpty(copyOfContextMap)) {
+            MDC.setContextMap(copyOfContextMap);
+        }
+        return t;
+    }
+}

--- a/src/test/java/it/pagopa/pn/mandate/middleware/db/MandateDaoIT.java
+++ b/src/test/java/it/pagopa/pn/mandate/middleware/db/MandateDaoIT.java
@@ -15,12 +15,10 @@ import it.pagopa.pn.mandate.utils.DateUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import reactor.core.publisher.Mono;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedAsyncClient;
 
@@ -30,7 +28,6 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest
 @Import(LocalStackTestConfig.class)
 public class MandateDaoIT {
@@ -715,7 +712,7 @@ public class MandateDaoIT {
         }
 
         //When
-        Mono<Void> mono = mandateDao.acceptMandate(mandateToInsert.getDelegate(), mandateToInsert.getMandateId(), mandateToInsert.getValidationcode());
+        Mono<MandateEntity> mono = mandateDao.acceptMandate(mandateToInsert.getDelegate(), mandateToInsert.getMandateId(), mandateToInsert.getValidationcode());
         assertThrows(PnInternalException.class, () -> mono.block(d));
 
 
@@ -741,7 +738,7 @@ public class MandateDaoIT {
         }
 
         //When
-        Mono<Void> mono = mandateDao.acceptMandate(mandateToInsert.getDelegate(), mandateToInsert.getMandateId(), wrongcode);
+        Mono<MandateEntity> mono = mandateDao.acceptMandate(mandateToInsert.getDelegate(), mandateToInsert.getMandateId(), wrongcode);
         assertThrows(PnInvalidVerificationCodeException.class, () -> mono.block(d));
 
 
@@ -769,7 +766,7 @@ public class MandateDaoIT {
         }
 
         //When
-        Mono<Void> mono = mandateDao.acceptMandate(wrongdelegate, mandateToInsert.getMandateId(), code);
+        Mono<MandateEntity> mono = mandateDao.acceptMandate(wrongdelegate, mandateToInsert.getMandateId(), code);
         assertThrows(PnMandateNotFoundException.class, () -> mono.block(d));
 
 

--- a/src/test/java/it/pagopa/pn/mandate/rest/mandate/MandateRestV1ControllerTest.java
+++ b/src/test/java/it/pagopa/pn/mandate/rest/mandate/MandateRestV1ControllerTest.java
@@ -3,6 +3,7 @@ package it.pagopa.pn.mandate.rest.mandate;
 import it.pagopa.pn.mandate.mapper.MandateEntityMandateDtoMapper;
 import it.pagopa.pn.mandate.mapper.UserEntityMandateCountsDtoMapper;
 import it.pagopa.pn.mandate.middleware.db.MandateDaoIT;
+import it.pagopa.pn.mandate.middleware.db.entities.MandateEntity;
 import it.pagopa.pn.mandate.rest.mandate.v1.dto.MandateCountsDto;
 import it.pagopa.pn.mandate.rest.mandate.v1.dto.MandateDto;
 import it.pagopa.pn.mandate.services.mandate.v1.MandateService;
@@ -68,7 +69,7 @@ class MandateRestV1ControllerTest {
 
         //When
         Mockito.when( mandateService.acceptMandate( Mockito.any(), Mockito.any() , Mockito.any()))
-                .thenReturn(Mono.just(""));
+                .thenReturn(Mono.just(new MandateEntity()));
 
         //Then
         webTestClient.patch()

--- a/src/test/java/it/pagopa/pn/mandate/services/mandate/v1/MandateServiceTest.java
+++ b/src/test/java/it/pagopa/pn/mandate/services/mandate/v1/MandateServiceTest.java
@@ -91,7 +91,7 @@ class MandateServiceTest {
         when(mandateDao.acceptMandate (Mockito.anyString(), Mockito.anyString(), Mockito.anyString())).thenReturn(Mono.empty());
 
         //When
-        Mono<Object> mono = mandateService.acceptMandate(mandateEntity.getMandateId(),
+        Mono<MandateEntity> mono = mandateService.acceptMandate(mandateEntity.getMandateId(),
                 Mono.just(acceptRequestDto), mandateEntity.getDelegate());
         assertThrows(PnInvalidVerificationCodeException.class, () -> mono.block(d));
 
@@ -110,7 +110,7 @@ class MandateServiceTest {
         when(mandateDao.acceptMandate (Mockito.anyString(), Mockito.anyString(), Mockito.anyString())).thenThrow(new PnInvalidVerificationCodeException());
 
         //When
-        Mono<Object> mono = mandateService.acceptMandate(mandateEntity.getMandateId(),
+        Mono<MandateEntity> mono = mandateService.acceptMandate(mandateEntity.getMandateId(),
                 Mono.just(acceptRequestDto), mandateEntity.getDelegate());
         assertThrows(PnInvalidVerificationCodeException.class, () -> mono.block(d));
 
@@ -130,7 +130,7 @@ class MandateServiceTest {
         when(mandateDao.acceptMandate (Mockito.anyString(), Mockito.anyString(), Mockito.anyString())).thenThrow(new PnMandateNotFoundException());
 
         //When
-        Mono<Object> mono = mandateService.acceptMandate(mandateEntity.getMandateId(),
+        Mono<MandateEntity> mono = mandateService.acceptMandate(mandateEntity.getMandateId(),
                 Mono.just(acceptRequestDto), mandateEntity.getDelegate());
         assertThrows(PnMandateNotFoundException.class, () -> mono.block(d));
 
@@ -151,7 +151,7 @@ class MandateServiceTest {
         //When
         Mono<AcceptRequestDto> monodto = Mono.just(acceptRequestDto);
         String delegate = mandateEntity.getDelegate();
-        Mono<Object> mono = mandateService.acceptMandate(null, monodto, delegate);
+        Mono<MandateEntity> mono = mandateService.acceptMandate(null, monodto, delegate);
         Assertions.assertThrows(PnMandateNotFoundException.class, () -> mono.block(d));
 
         //Then


### PR DESCRIPTION
Attività svolte:

- scritte classi decorator per aggiungere log MDC in chiamate asincrone su dynamo
- refactoring metodo acceptMandate (snellito in più parti, la logica non è stata cambiata)
- eliminato utilizzo errato di PnAutitLogBuilder come bean singleton (non è thread-safe)